### PR TITLE
Add documentation for all applications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# SaveBucks Development Guide
+
+This document provides conventions and architectural notes for working with the SaveBucks monorepo. Use it as a reference when contributing to any of the contained applications.
+
+## Architectural Overview
+
+The repository consists of three primary applications:
+
+1. **Admin** – Laravel Filament application used for back‑office management.
+2. **API** – Fastify/TypeScript server exposing REST and socket endpoints.
+3. **Web** – Next.js React frontend consumed by end users.
+
+Applications communicate mainly through the API layer. Keep services decoupled and use environment variables for configuration.
+
+## Coding Standards
+
+- **PHP**: Follow [PSR‑12](https://www.php-fig.org/psr/psr-12/). Laravel facades should be type‑hinted and service classes injected via the container.
+- **Node/TypeScript**: Use async/await, keep modules small and focused, and prefer Fastify plugins for extensibility.
+- **React**: Utilize functional components and hooks. Keep styling in Tailwind CSS classes.
+
+## Commit Messages
+
+Use the conventional commit style:
+
+```
+feat: short description of a new feature
+fix: short description of a bug fix
+chore: routine maintenance
+```
+
+## Branching Strategy
+
+- Work from `main` for production releases.
+- Feature branches use the prefix `feature/` and bug fixes use `fix/`.
+- Submit pull requests for review before merging.
+
+## Guardrails
+
+- Avoid raw SQL queries; rely on an ORM (Eloquent, Kysely) or query builder.
+- Never hardcode secrets—use environment variables.
+- Do not use inline styles; prefer Tailwind CSS or component styling.
+
+## To‑Dos
+
+- Set up comprehensive logging for all applications.
+- Configure CI/CD pipelines for automated testing and deployment.
+- Ensure that every API endpoint is properly authenticated.
+
+## Best Practices
+
+- Apply SOLID and DRY principles when structuring code.
+- Write unit tests for business logic and integration tests for critical flows.
+- Document new modules and keep this guide up to date.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# SaveBucks Monorepo
+
+SaveBucks is a multi-application repository containing three core projects:
+
+- **Admin** – Laravel Filament PHP application providing the administrative interface.
+- **API** – Fastify Node application exposing REST endpoints and real-time services.
+- **Web** – Next.js React application serving the customer-facing website.
+
+This monorepo aims to consolidate development and deployment of all services.
+
+## Architecture Diagram
+
+```text
++---------+       HTTP      +-------+
+|  Web    | <------------> |  API  |
++---------+                 +-------+
+     ^                           ^
+     |                           |
+     |   Admin actions via API   |
+     +-------->+---------+<------+
+               | Admin   |
+               +---------+
+```
+
+## Technologies Used
+
+- PHP 8 / Laravel / Filament
+- Node.js / Fastify / TypeScript
+- React / Next.js / Tailwind CSS
+- MySQL, Redis and other supporting services
+
+## Folder Structure Overview
+
+```
+/ (repo root)
+├── admin        # Laravel Filament application
+├── api          # Fastify API server
+├── web          # Next.js web frontend
+└── chat-client  # Static chat prototype (HTML)
+```
+
+## Getting Started
+
+### Prerequisites
+
+- **PHP** >= 8.1 with Composer
+- **Node.js** >= 18
+- MySQL or compatible database server
+
+### Installation
+
+Clone the repository and install each application’s dependencies:
+
+```bash
+# Admin
+cd admin
+composer install
+cp .env.example .env
+php artisan key:generate
+
+# API
+cd ../api
+npm install
+
+# Web
+cd ../web
+npm install
+```
+
+### Running Locally
+
+```
+# Admin
+php artisan serve
+
+# API
+npm run dev
+
+# Web
+npm run dev
+```
+
+## Development Guidelines
+
+- Follow PSR-12 for PHP code and ESLint/Prettier rules for JavaScript/TypeScript.
+- Use clear commit messages (`feat:`, `fix:`, etc.) and create pull requests for all changes.
+- Main development occurs on `main`; feature branches follow the pattern `feature/<name>`.
+
+## Deployment Instructions
+
+Each application can be deployed independently.
+
+- **Admin**: run database migrations and configure the web server to point to the `public/` directory.
+- **API**: build or run with `ts-node`, configure environment variables and reverse proxy (e.g., Nginx).
+- **Web**: execute `npm run build` then serve with `next start` or export as static assets.
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Follow coding standards and ensure no sensitive data is committed.
+3. Open a pull request describing your changes.
+

--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -1,0 +1,37 @@
+# Admin Application Guide
+
+This guide describes technical details and recommendations for the Laravel Filament admin panel.
+
+## Architecture Overview
+
+The application follows Laravel's MVC structure with Filament providing panel pages and resources. Most business logic resides in service classes invoked from controllers or Filament actions.
+
+## Component Breakdown
+
+- **Resources** – Manage CRUD interfaces for models.
+- **Pages** – Custom admin pages such as dashboards or settings.
+- **Widgets** – Small UI components showing stats or charts.
+
+## Data Flow
+
+Requests are routed through `routes/web.php` and handled by controllers or Filament resources. Models use Eloquent ORM to interact with the database.
+
+## Security Considerations
+
+- Authentication uses Laravel's session guard.
+- Authorization is implemented through policies and the Filament Shield package.
+- Sensitive configuration is stored in `.env` variables.
+
+## Performance Optimization
+
+- Cache heavy queries using Laravel's cache system.
+- Use eager loading to avoid N+1 database issues.
+
+## Testing Strategy
+
+PHPUnit tests live in the `tests/` directory. Add feature tests for controllers and unit tests for services.
+
+## Known Issues & Limitations
+
+None documented yet. Update this file when limitations are discovered.
+

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,51 @@
+# Admin Application
+
+The Admin app is a Laravel Filament project that provides an interface for managing users, offers and platform configuration.
+
+## Setup Instructions
+
+1. Install PHP dependencies:
+   ```bash
+   composer install
+   ```
+2. Copy the example environment file and generate an application key:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   ```
+3. Run database migrations and seeders as required:
+   ```bash
+   php artisan migrate --seed
+   ```
+4. Start the local development server:
+   ```bash
+   php artisan serve
+   ```
+
+## Application Structure
+
+```
+app/        # Controllers, models and Filament resources
+config/     # Application configuration
+resources/  # Blade templates and assets
+routes/     # Route definitions
+```
+
+## Key Features
+
+- **Filament** dashboard for a consistent admin UI.
+- Eloquent ORM for all database interactions.
+- Policies and permissions via Filament Shield.
+
+## Best Practices
+
+- Follow PSR-12 coding style.
+- Use Laravel validation and centralized error handling.
+- Apply middleware to protect routes and filter requests.
+
+## Deployment
+
+1. Run `composer install --no-dev --optimize-autoloader`.
+2. Execute `php artisan migrate --force`.
+3. Point the web server document root to the `public/` directory.
+

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,37 @@
+# API Application Guide
+
+This file explains the internal structure and guidelines for the Fastify API.
+
+## Architecture Overview
+
+The API initializes a Fastify instance in `src/app.ts` and loads feature modules via Fastify plugins. TypeScript is used throughout the codebase.
+
+## Component Breakdown
+
+- **modules/** – Contains route handlers grouped by feature.
+- **service/** – Houses business logic and external integrations.
+- **plugins/** – Custom Fastify plugins and shared functionality.
+
+## Data Flow
+
+Incoming requests enter through Fastify routes, pass through middleware and reach controllers. Controllers delegate to services which communicate with the database using Kysely or other query builders.
+
+## Security Considerations
+
+- Authentication is implemented with Fastify Passport and JWT.
+- Rate limiting and helmet are enabled for basic protection.
+- Secrets are loaded from environment variables.
+
+## Performance Optimization
+
+- Leverage Fastify's plugin architecture for lightweight routes.
+- Use connection pooling for database access and enable caching where possible.
+
+## Testing Strategy
+
+Write unit tests for services and integration tests for routes using your preferred framework (e.g., Tap or Jest).
+
+## Known Issues & Limitations
+
+None at this time. Document future issues here.
+

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,42 @@
+# API Application
+
+The API is built with Fastify and TypeScript. It exposes RESTful endpoints and socket services that power the web and admin applications.
+
+## Setup Instructions
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example configuration if provided and set environment variables.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Application Structure
+
+```
+src/
+  app.ts        # Fastify server bootstrap
+  modules/      # Feature modules and routes
+  plugins/      # Fastify plugins
+  service/      # Business logic services
+```
+
+## Key Features
+
+- Fastify for a high-performance HTTP server.
+- Database access through TypeScript query builders.
+- Authentication and authorization middleware.
+
+## Best Practices
+
+- Follow REST principles when designing routes.
+- Use async/await and handle errors gracefully.
+- Emit logs for requests and errors.
+
+## Deployment
+
+Run the server with a process manager (e.g., pm2) or containerize the application. Configure environment variables for production and start with `node` or `ts-node`.
+

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,36 @@
+# Web Application Guide
+
+This guide outlines architecture and conventions for the Next.js frontend.
+
+## Architecture Overview
+
+The project uses the Next.js App Router with React components organized under `src/`. Styling relies on Tailwind CSS and components from NextUI.
+
+## Component Breakdown
+
+- **app/** – Route definitions and page layouts.
+- **components/** – Shared UI components.
+- **lib/** – Helpers for API access and utilities.
+
+## Data Flow
+
+Pages and components fetch data from the Fastify API using fetch or specialized client libraries. State is managed with React hooks and context.
+
+## Security Considerations
+
+- Environment variables are loaded from `.env.local`.
+- Avoid exposing secrets to the client; only safe variables prefixed with `NEXT_PUBLIC_` should be used.
+
+## Performance Optimization
+
+- Use Next.js dynamic imports and caching strategies.
+- Optimize images with the built-in `next/image` component.
+
+## Testing Strategy
+
+Unit test components with Jest and React Testing Library. End-to-end tests can be written with Playwright or Cypress.
+
+## Known Issues & Limitations
+
+No major issues recorded.
+

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,46 @@
+# Web Application
+
+The Web app is built with Next.js and React to deliver a responsive user interface.
+
+## Setup Instructions
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure environment variables as required in `.env.local`.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Application Structure
+
+```
+src/
+  app/         # Next.js App Router and pages
+  components/  # Reusable React components
+  lib/         # Utilities and helpers
+```
+
+## Key Features
+
+- Server-side rendering and static generation with Next.js.
+- React components styled with Tailwind CSS.
+- State management using React context and hooks.
+
+## Best Practices
+
+- Prefer functional components and custom hooks.
+- Keep styling in Tailwind classes or CSS modules.
+- Ensure layouts are responsive across devices.
+
+## Deployment
+
+Build the application and start in production mode:
+
+```bash
+npm run build
+npm start
+```
+


### PR DESCRIPTION
## Summary
- add monorepo overview in root README
- describe development standards and guardrails in AGENTS.md
- document Admin, API and Web apps with READMEs
- provide app-specific guides in AGENTS.md files

## Testing
- `composer validate --no-check-all` in `admin`
- `npm test` in `api` *(fails: no test specified)*
- `npm test` in `web` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879f72805b4832dbf94b238e861532f