### PR TITLE
Add campaign selection for links and postback

### DIFF
--- a/affiliate-panel/app/(public)/l/[slug]/page.tsx
+++ b/affiliate-panel/app/(public)/l/[slug]/page.tsx
@@ -64,7 +64,7 @@ export default async function Page({
   }
 
   const data = {
-    campaignId: 1,
+    campaignId: affiliateLink.campaignId,
     affiliateId: affiliateLink.affiliateId,
     affiliateLinkId: affiliateLink.id,
     clickCode,

--- a/affiliate-panel/app/api/campaigns/route.ts
+++ b/affiliate-panel/app/api/campaigns/route.ts
@@ -1,0 +1,22 @@
+import { createTranslation } from "@/i18n/server";
+import { getAllCampaigns } from "@/models/campaigns-model";
+import { commonResponse } from "@/utils/response-format";
+import { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { t } = await createTranslation();
+  try {
+    const result = await getAllCampaigns({ filters: { status: "active" } });
+    return commonResponse({
+      data: result.data?.result || [],
+      status: "success",
+      message: "ok",
+    });
+  } catch (error) {
+    return commonResponse({
+      data: null,
+      status: "error",
+      message: t("somethingWentWrong"),
+    });
+  }
+}

--- a/affiliate-panel/app/api/crons/process-conversion/route.ts
+++ b/affiliate-panel/app/api/crons/process-conversion/route.ts
@@ -78,9 +78,12 @@ export async function POST(request: NextRequest) {
           clickRecord
         );
 
-        let campaign = (await getCampaignById(clickRecord.campaignId))?.data;
-        let campaignGoal = (await getCampaignGoalByTrackingCode(tracking_code))
-          ?.data;
+        const campaignId = body.campaign_id
+          ? Number(body.campaign_id)
+          : clickRecord.campaignId;
+
+        let campaign = campaignId ? (await getCampaignById(campaignId))?.data : null;
+        let campaignGoal = (await getCampaignGoalByTrackingCode(tracking_code))?.data;
         let affiliateCampaignGoal = null;
 
         console.log(
@@ -180,9 +183,7 @@ export async function POST(request: NextRequest) {
 
           const newConversion = {
             campaignGoalId: goal_code ? Number(goal_code) : 1,
-            campaignId: clickRecord.campaignId
-              ? Number(clickRecord.campaignId)
-              : 1,
+            campaignId: campaignId || null,
             clickCode: clickRecord.clickCode,
             affiliateId: clickRecord.affiliateId,
             transactionId: `${transaction_id}_${goal_code}`,
@@ -229,7 +230,7 @@ export async function POST(request: NextRequest) {
           const affiliatePostback = (
             await getAffiliatePostbackByCampaignAndGoal(
               clickRecord.affiliateId,
-              clickRecord.campaignId ? Number(clickRecord.campaignId) : 1,
+              campaignId || 0,
               Number(goal_code)
             )
           )?.data;
@@ -242,9 +243,7 @@ export async function POST(request: NextRequest) {
               const postbackData: any = {
                 affiliate_id: clickRecord.affiliateId,
                 affiliate_link_id: clickRecord.affiliateLinkId,
-                campaign_id: clickRecord.campaignId
-                  ? Number(clickRecord.campaignId)
-                  : 1,
+                campaign_id: campaignId || 0,
                 link_name: link_name,
                 goal_name: campaignGoal?.name,
                 campaign_goal_id: goal_code ? Number(goal_code) : 1,

--- a/affiliate-panel/components/settings/ConfigurePostback.tsx
+++ b/affiliate-panel/components/settings/ConfigurePostback.tsx
@@ -17,12 +17,18 @@ import { postbackSchema } from "@/utils/validation";
 import { Api } from "@/services/api-services";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "@/i18n/client";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import Textarea from "../ui/Textarea";
 
-export default function ConfigurePostback({ goals }: any) {
+export default function ConfigurePostback({
+  goals,
+  campaigns,
+  selectedCampaignId,
+}: any) {
   const { t } = useTranslation();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const user = useSession().data?.user;
 
   const initialValues = {
@@ -33,6 +39,16 @@ export default function ConfigurePostback({ goals }: any) {
     methodType: undefined,
   };
 
+  const handleCampaignChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set("campaignId", value);
+    } else {
+      params.delete("campaignId");
+    }
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
   const handleSubmit = async (
     values: any,
     { setSubmitting, resetForm }: any
@@ -41,7 +57,7 @@ export default function ConfigurePostback({ goals }: any) {
       setSubmitting(true);
       const data = {
         affiliateId: user?.id,
-        campaignId: 1,
+        campaignId: selectedCampaignId,
         campaignGoalId:
           values.postbackType === "goal"
             ? goals?.find((g: any) => g.name === values.selectedGoal).id
@@ -82,6 +98,28 @@ export default function ConfigurePostback({ goals }: any) {
     <Card>
       <CardContent className="p-4 sm:p-6">
         <h2 className="text-lg font-medium mb-6">{t("postback.title")}</h2>
+        <div className="mb-6">
+          <Label htmlFor="campaign" className="text-sm text-gray-600">
+            {t("campaign.selectCampaign")}
+          </Label>
+          <Select
+            value={String(selectedCampaignId)}
+            onValueChange={handleCampaignChange}
+          >
+            <SelectTrigger className="bg-white mt-1">
+              <SelectValue
+                placeholder={t("campaign.selectPlaceholder")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {campaigns.map((c: any) => (
+                <SelectItem key={c.id} value={String(c.id)}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
         <Formik
           initialValues={initialValues}

--- a/affiliate-panel/i18n/locales/en/common.json
+++ b/affiliate-panel/i18n/locales/en/common.json
@@ -280,7 +280,9 @@
   "fallbackDescription": "Campaign Description.",
   "earn": "{amount}",
   "termsAndConditions": "Terms & Conditions",
-  "noActiveCampaigns": "No active campaigns found."
+  "noActiveCampaigns": "No active campaigns found.",
+  "selectCampaign": "Select Campaign",
+  "selectPlaceholder": "Choose campaign"
 },
 "earnings": {
   "chartTitle": "Total Earnings ($)",

--- a/affiliate-panel/utils/validation.ts
+++ b/affiliate-panel/utils/validation.ts
@@ -89,6 +89,7 @@ export const PersonalInformationSchema = Yup.object().shape({
 });
 
 export const AffiliateLinkSchema = Yup.object({
+  campaignId: Yup.number().required("Campaign is required"),
   link: Yup.string()
     .required("Keyword is required")
     .min(3, "Keyword must be at least 3 characters")


### PR DESCRIPTION
## Summary
- create campaigns API route
- fetch campaigns for link creation and require campaign selection
- allow selecting campaign when configuring postbacks
- use selected campaign id throughout settings
- track clicks using affiliate link campaign id
- handle campaign id fallback in conversion cron

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687bdc13aff4832d8e655f0d033dfe06