### PR TITLE
Add campaign filtering across affiliate tables

### DIFF
--- a/affiliate-panel/app/(protected)/links/page.tsx
+++ b/affiliate-panel/app/(protected)/links/page.tsx
@@ -9,7 +9,7 @@ import { AppRoutes } from "@/utils/routes";
 import { redirect } from "next/navigation";
 
 export default async function LinksPage({ searchParams }: any) {
-  const { from, to, rows_per_page, page } = searchParams;
+  const { from, to, rows_per_page, page, campaignId } = searchParams;
   const { t } = await createTranslation();
   const user = await getAuthSession();
   const userStatus = user?.user?.status;
@@ -26,6 +26,7 @@ export default async function LinksPage({ searchParams }: any) {
         to,
         rows_per_page,
         page,
+        campaignId,
       })
     )?.data || [];
 
@@ -37,7 +38,7 @@ export default async function LinksPage({ searchParams }: any) {
 
       <ActiveCampaign campaigns={campaigns || []} />
 
-      <LinksTable data={data} />
+      <LinksTable data={data} campaignId={campaignId} />
     </DashboardLayout>
   );
 }

--- a/affiliate-panel/app/(protected)/payouts/page.tsx
+++ b/affiliate-panel/app/(protected)/payouts/page.tsx
@@ -24,7 +24,7 @@ export default async function PayoutsPage({ searchParams }: any) {
   if (userStatus === "pending") {
     return redirect(AppRoutes.auth.pending);
   }
-  const { from, to, rows_per_page, page } = searchParams;
+  const { from, to, rows_per_page, page, campaignId } = searchParams;
   const affilite = (await getAffiliateById(user.user.id))?.data || null;
   const minAmount = (await getCampaignById(1))?.data?.minPayoutAmount || 0;
   const paymentInfo = {
@@ -38,6 +38,7 @@ export default async function PayoutsPage({ searchParams }: any) {
         to,
         rows_per_page,
         page,
+        campaignId,
       })
     )?.data || [];
 
@@ -82,7 +83,7 @@ export default async function PayoutsPage({ searchParams }: any) {
           minAmount={minAmount}
         />
 
-        <PayoutsTable data={payouts} />
+        <PayoutsTable data={payouts} campaignId={campaignId} />
       </div>
     </DashboardLayout>
   );

--- a/affiliate-panel/app/(protected)/settings/page.tsx
+++ b/affiliate-panel/app/(protected)/settings/page.tsx
@@ -21,7 +21,7 @@ export default async function SettingsPage({ searchParams }: any) {
     return redirect(AppRoutes.auth.pending);
   }
   const { t } = await createTranslation();
-  const { from, to, rows_per_page, page } = searchParams;
+  const { from, to, rows_per_page, page, campaignId } = searchParams;
   if (!user) {
     return redirect(AppRoutes.auth.signIn);
   }
@@ -56,6 +56,7 @@ export default async function SettingsPage({ searchParams }: any) {
       to,
       rows_per_page,
       page,
+      campaignId,
     })
   ).data;
 
@@ -73,7 +74,7 @@ export default async function SettingsPage({ searchParams }: any) {
         {/* Configure Postback */}
         <ConfigurePostback goals={finalGoals} />
 
-        <PostbacksTable data={postbacks} />
+        <PostbacksTable data={postbacks} campaignId={campaignId} />
 
         {/* Postback Documentation */}
         <Card>

--- a/affiliate-panel/app/(protected)/transactions/page.tsx
+++ b/affiliate-panel/app/(protected)/transactions/page.tsx
@@ -4,11 +4,12 @@ import FilterComponent from "@/components/transactions/FilterComponent";
 import { createTranslation } from "@/i18n/server";
 import { getAuthSession } from "@/models/auth-models";
 import { getAllAffiliateTransactions } from "@/models/conversions-model";
+import { getAllCampaigns } from "@/models/campaigns-model";
 import { AppRoutes } from "@/utils/routes";
 import { redirect } from "next/navigation";
 
 export default async function TransactionsPage({ searchParams }: any) {
-  const { from, to, status, rows_per_page, page } = searchParams;
+  const { from, to, status, rows_per_page, page, campaignId } = searchParams;
   const user = await getAuthSession();
   const userStatus = user?.user?.status;
 
@@ -16,6 +17,7 @@ export default async function TransactionsPage({ searchParams }: any) {
     return redirect(AppRoutes.auth.pending);
   }
   const { t } = await createTranslation();
+  const campaigns = (await getAllCampaigns({}))?.data?.result || [];
   const transactions =
     (await getAllAffiliateTransactions(
       user.user.id,
@@ -23,7 +25,8 @@ export default async function TransactionsPage({ searchParams }: any) {
       page,
       status,
       from,
-      to
+      to,
+      campaignId
     )) || [];
 
   return (
@@ -32,7 +35,7 @@ export default async function TransactionsPage({ searchParams }: any) {
         <h1 className="text-2xl font-semibold">{t("transactions.title")}</h1>
       </div>
 
-      <FilterComponent />
+      <FilterComponent campaigns={campaigns} />
 
       <TransactionsTable transactions={transactions} />
     </DashboardLayout>

--- a/affiliate-panel/components/links/LinksTable.tsx
+++ b/affiliate-panel/components/links/LinksTable.tsx
@@ -29,7 +29,7 @@ import { useRouter } from "next/navigation";
 import TablePagination from "../TablePagination";
 import DateFilter from "../DateFilter";
 
-export default function LinksTable({ data }: { data: any }) {
+export default function LinksTable({ data, campaignId }: { data: any; campaignId?: string }) {
   const { t } = useTranslation();
   const router = useRouter();
 

--- a/affiliate-panel/components/payouts/PayoutsTable.tsx
+++ b/affiliate-panel/components/payouts/PayoutsTable.tsx
@@ -29,7 +29,7 @@ import DateFilter from "../DateFilter";
 
 type PayoutStatus = "paid" | "pending" | "rejected" | "processing";
 
-export default function PayoutsTable({ data }: any) {
+export default function PayoutsTable({ data, campaignId }: { data: any; campaignId?: string }) {
   const { t } = useTranslation();
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);

--- a/affiliate-panel/components/settings/PostbackTable.tsx
+++ b/affiliate-panel/components/settings/PostbackTable.tsx
@@ -34,7 +34,7 @@ import { Api } from "@/services/api-services";
 import { toast } from "@/hooks/use-toast";
 import DateFilter from "../DateFilter";
 
-export default function PostbacksTable({ data }: any) {
+export default function PostbacksTable({ data, campaignId }: { data: any; campaignId?: string }) {
   const { t } = useTranslation();
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/affiliate-panel/components/transactions/FilterComponent.tsx
+++ b/affiliate-panel/components/transactions/FilterComponent.tsx
@@ -30,9 +30,12 @@ const getDateFromParams = (param: string): Date | undefined => {
   return isNaN(date.getTime()) ? undefined : date;
 };
 
-export default function FilterComponent() {
+export default function FilterComponent({ campaigns = [] }: { campaigns?: any[] }) {
   const { t } = useTranslation();
   const [statusFilter, setStatusFilter] = useState("all");
+  const [campaignFilter, setCampaignFilter] = useState(
+    searchParams.get("campaignId") || "all"
+  );
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
@@ -68,10 +71,12 @@ export default function FilterComponent() {
     router.push(`${pathname}?${params.toString()}`);
   };
 
-  const hasActiveFilters = statusFilter !== "all" || (date?.from && date?.to);
+  const hasActiveFilters =
+    statusFilter !== "all" || campaignFilter !== "all" || (date?.from && date?.to);
 
   const clearFilters = () => {
     setStatusFilter("all");
+    setCampaignFilter("all");
     setDate(undefined);
     router.push(pathname);
   };
@@ -83,7 +88,7 @@ export default function FilterComponent() {
       </CardHeader>
       <CardContent>
         <div className="space-y-4 sm:space-y-6">
-          <div className="grid md:grid-cols-2 gap-4">
+          <div className="grid md:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label>{t("filters.status.label")}</Label>
               <Select
@@ -107,6 +112,27 @@ export default function FilterComponent() {
                   <SelectItem value="declined">
                     {t("filters.status.declined")}
                   </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>{t("filters.campaign.label")}</Label>
+              <Select
+                value={campaignFilter}
+                onValueChange={(value) => {
+                  setCampaignFilter(value);
+                  updateSearchParams("campaignId", value);
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={t("filters.campaign.all")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("filters.campaign.all")}</SelectItem>
+                  {campaigns.map((c) => (
+                    <SelectItem key={c.id} value={`${c.id}`}>{c.name}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/affiliate-panel/i18n/locales/en/common.json
+++ b/affiliate-panel/i18n/locales/en/common.json
@@ -330,6 +330,10 @@
     "pending": "Pending",
     "declined": "Declined"
   },
+  "campaign": {
+    "label": "Campaign",
+    "all": "All campaigns"
+  },
   "dateRange": "Date Range",
   "placeholder": "Pick a date",
   "clear": "Clear filters"

--- a/affiliate-panel/models/affiliate-link-model/index.ts
+++ b/affiliate-panel/models/affiliate-link-model/index.ts
@@ -241,6 +241,12 @@ export const getAffiliateLinksByAffiliateId = async (
       whereConditions.push(eq(affiliateLinks.status, filters.status));
     }
 
+    if (filters?.campaignId) {
+      whereConditions.push(
+        eq(affiliateLinks.campaignId, parseInt(filters.campaignId))
+      );
+    }
+
     const whereClause = and(...whereConditions);
 
     const countResult = await db

--- a/affiliate-panel/models/conversions-model/index.ts
+++ b/affiliate-panel/models/conversions-model/index.ts
@@ -540,7 +540,8 @@ export const getAllAffiliateTransactions = async (
   page: number = 1,
   status?: "pending" | "approved" | "declined" | "paid",
   from?: string,
-  to?: string
+  to?: string,
+  campaignId?: string
 ) => {
   try {
     const defaultTo = new Date();
@@ -561,6 +562,12 @@ export const getAllAffiliateTransactions = async (
     if (status) {
       whereConditions.push(
         eq(affiliateConversionsSummary.conversionStatus, status)
+      );
+    }
+
+    if (campaignId) {
+      whereConditions.push(
+        eq(affiliateConversionsSummary.campaignId, parseInt(campaignId))
       );
     }
 

--- a/affiliate-panel/models/payouts-model/index.ts
+++ b/affiliate-panel/models/payouts-model/index.ts
@@ -122,6 +122,10 @@ export const getPayoutsByAffiliateId = async (
       lte(payouts.createdAt, toDate),
     ];
 
+    if (filters?.campaignId) {
+      whereConditions.push(eq(payouts.campaignId, parseInt(filters.campaignId)));
+    }
+
     const whereClause = and(...whereConditions);
 
     const countResult = await db


### PR DESCRIPTION
## Summary
- support filtering by `campaignId` in transactions filter component
- propagate `campaignId` query param through links, payouts and settings pages
- update links, payouts and postbacks table components to accept campaign context
- apply campaign filters in affiliate data fetchers
- extend i18n strings for new campaign filter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bdc1e7b84832db2ba3428dfcfb3af