### PR TITLE
Add affiliate reports page

### DIFF
--- a/affiliate-panel/app/(protected)/reports/page.tsx
+++ b/affiliate-panel/app/(protected)/reports/page.tsx
@@ -5,7 +5,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { createTranslation } from "@/i18n/server";
 import { getAuthSession } from "@/models/auth-models";
 import { getAllCampaigns } from "@/models/campaigns-model";
-import { getAffiliateDailyReport, getAffiliateMonthlyReport } from "@/models/conversions-model";
+import {
+  getAffiliateDailyReport,
+  getAffiliateMonthlyReport,
+  getAffiliateAvailableMonths,
+} from "@/models/conversions-model";
 import { AppRoutes } from "@/utils/routes";
 import { redirect } from "next/navigation";
 
@@ -20,6 +24,7 @@ export default async function ReportsPage({ searchParams }: any) {
 
   const { t } = await createTranslation();
   const campaigns = (await getAllCampaigns({ affiliateId: Number(user.user.id) }))?.data?.result || [];
+  const months = (await getAffiliateAvailableMonths(user.user.id))?.data || [];
 
   const dailyData = (
     await getAffiliateDailyReport(user.user.id, { status, campaignId, month, year })
@@ -39,11 +44,11 @@ export default async function ReportsPage({ searchParams }: any) {
           <TabsTrigger value="monthly">{t("reports.monthly")}</TabsTrigger>
         </TabsList>
         <TabsContent value="daily">
-          <FilterComponent campaigns={campaigns} showMonth />
+          <FilterComponent campaigns={campaigns} showMonth months={months} />
           <ReportsTable data={dailyData} dateLabel={t("reports.table.date")} />
         </TabsContent>
         <TabsContent value="monthly">
-          <FilterComponent campaigns={campaigns} showYear />
+          <FilterComponent campaigns={campaigns} showYear showDateRange={false} />
           <ReportsTable data={monthlyData} dateLabel={t("reports.table.month")} />
         </TabsContent>
       </Tabs>

--- a/affiliate-panel/app/(protected)/reports/page.tsx
+++ b/affiliate-panel/app/(protected)/reports/page.tsx
@@ -1,0 +1,52 @@
+import { DashboardLayout } from "@/components/layouts/DashboardLayout";
+import FilterComponent from "@/components/transactions/FilterComponent";
+import ReportsTable from "@/components/dashboard/reports-table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { createTranslation } from "@/i18n/server";
+import { getAuthSession } from "@/models/auth-models";
+import { getAllCampaigns } from "@/models/campaigns-model";
+import { getAffiliateDailyReport, getAffiliateMonthlyReport } from "@/models/conversions-model";
+import { AppRoutes } from "@/utils/routes";
+import { redirect } from "next/navigation";
+
+export default async function ReportsPage({ searchParams }: any) {
+  const { month, year, status, campaignId } = searchParams;
+  const user = await getAuthSession();
+  const userStatus = user?.user?.status;
+
+  if (userStatus === "pending") {
+    return redirect(AppRoutes.auth.pending);
+  }
+
+  const { t } = await createTranslation();
+  const campaigns = (await getAllCampaigns({ affiliateId: Number(user.user.id) }))?.data?.result || [];
+
+  const dailyData = (
+    await getAffiliateDailyReport(user.user.id, { status, campaignId, month, year })
+  )?.data || [];
+  const monthlyData = (
+    await getAffiliateMonthlyReport(user.user.id, { status, campaignId, year })
+  )?.data || [];
+
+  return (
+    <DashboardLayout>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-semibold">{t("reports.title")}</h1>
+      </div>
+      <Tabs defaultValue="daily" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="daily">{t("reports.daily")}</TabsTrigger>
+          <TabsTrigger value="monthly">{t("reports.monthly")}</TabsTrigger>
+        </TabsList>
+        <TabsContent value="daily">
+          <FilterComponent campaigns={campaigns} showMonth />
+          <ReportsTable data={dailyData} dateLabel={t("reports.table.date")} />
+        </TabsContent>
+        <TabsContent value="monthly">
+          <FilterComponent campaigns={campaigns} showYear />
+          <ReportsTable data={monthlyData} dateLabel={t("reports.table.month")} />
+        </TabsContent>
+      </Tabs>
+    </DashboardLayout>
+  );
+}

--- a/affiliate-panel/app/(protected)/reports/page.tsx
+++ b/affiliate-panel/app/(protected)/reports/page.tsx
@@ -14,7 +14,7 @@ import { AppRoutes } from "@/utils/routes";
 import { redirect } from "next/navigation";
 
 export default async function ReportsPage({ searchParams }: any) {
-  const { month, year, status, campaignId } = searchParams;
+  const { month, year, status, campaignId, from, to } = searchParams;
   const user = await getAuthSession();
   const userStatus = user?.user?.status;
 
@@ -23,15 +23,30 @@ export default async function ReportsPage({ searchParams }: any) {
   }
 
   const { t } = await createTranslation();
-  const campaigns = (await getAllCampaigns({ affiliateId: Number(user.user.id) }))?.data?.result || [];
+  const campaigns =
+    (await getAllCampaigns({ affiliateId: Number(user.user.id) }))?.data
+      ?.result || [];
   const months = (await getAffiliateAvailableMonths(user.user.id))?.data || [];
 
-  const dailyData = (
-    await getAffiliateDailyReport(user.user.id, { status, campaignId, month, year })
-  )?.data || [];
-  const monthlyData = (
-    await getAffiliateMonthlyReport(user.user.id, { status, campaignId, year })
-  )?.data || [];
+  const dailyData =
+    (
+      await getAffiliateDailyReport(user.user.id, {
+        status,
+        campaignId,
+        month,
+        year,
+        from,
+        to,
+      })
+    )?.data || [];
+  const monthlyData =
+    (
+      await getAffiliateMonthlyReport(user.user.id, {
+        status,
+        campaignId,
+        year,
+      })
+    )?.data || [];
 
   return (
     <DashboardLayout>
@@ -48,8 +63,15 @@ export default async function ReportsPage({ searchParams }: any) {
           <ReportsTable data={dailyData} dateLabel={t("reports.table.date")} />
         </TabsContent>
         <TabsContent value="monthly">
-          <FilterComponent campaigns={campaigns} showYear showDateRange={false} />
-          <ReportsTable data={monthlyData} dateLabel={t("reports.table.month")} />
+          <FilterComponent
+            campaigns={campaigns}
+            showYear
+            showDateRange={false}
+          />
+          <ReportsTable
+            data={monthlyData}
+            dateLabel={t("reports.table.month")}
+          />
         </TabsContent>
       </Tabs>
     </DashboardLayout>

--- a/affiliate-panel/components/dashboard/reports-table.tsx
+++ b/affiliate-panel/components/dashboard/reports-table.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTranslation } from "@/i18n/client";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import TablePagination from "../TablePagination";
+import { getCurrencySymbol } from "@/utils/getCurrency";
+
+interface ReportRow {
+  date?: string;
+  month?: number;
+  transactions: number;
+  earning: string | number;
+}
+
+export default function ReportsTable({
+  data,
+  dateLabel,
+  pagination,
+}: {
+  data: ReportRow[];
+  dateLabel: string;
+  pagination?: any;
+}) {
+  const { t } = useTranslation();
+
+  const columns: ColumnDef<ReportRow>[] = [
+    {
+      accessorKey: "date",
+      header: dateLabel,
+      cell: ({ row }) => (
+        <div className="flex items-center">
+          {row.original.date || row.original.month}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "transactions",
+      header: t("reports.table.transactions"),
+      cell: ({ row }) => (
+        <div className="flex items-center">{row.original.transactions}</div>
+      ),
+    },
+    {
+      accessorKey: "earning",
+      header: t("reports.table.earning"),
+      cell: ({ row }) => (
+        <div className="flex items-center">
+          {getCurrencySymbol() + Number(row.original.earning || 0).toFixed(2)}
+        </div>
+      ),
+    },
+  ];
+
+  const table = useReactTable({
+    data: data || [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    initialState: {
+      pagination: {
+        pageSize: 10,
+      },
+    },
+  });
+
+  return (
+    <Card className="border rounded-2xl">
+      <CardHeader>
+        <CardTitle>{t("reports.title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows?.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center"
+                    >
+                      {t("reports.table.empty")}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          {pagination && (
+            <TablePagination table={table} pagination={pagination} />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/affiliate-panel/components/transactions/FilterComponent.tsx
+++ b/affiliate-panel/components/transactions/FilterComponent.tsx
@@ -32,8 +32,12 @@ const getDateFromParams = (param: string): Date | undefined => {
 
 export default function FilterComponent({
   campaigns = [],
+  showMonth = false,
+  showYear = false,
 }: {
   campaigns?: any[];
+  showMonth?: boolean;
+  showYear?: boolean;
 }) {
   const { t } = useTranslation();
   const router = useRouter();
@@ -44,6 +48,11 @@ export default function FilterComponent({
   const [campaignFilter, setCampaignFilter] = useState(
     searchParams.get("campaignId") || "all"
   );
+
+  const [monthFilter, setMonthFilter] = useState(
+    searchParams.get("month") || "all"
+  );
+  const [yearFilter, setYearFilter] = useState(searchParams.get("year") || "all");
 
   const fromParam = searchParams.get("from");
   const toParam = searchParams.get("to");
@@ -78,12 +87,16 @@ export default function FilterComponent({
   const hasActiveFilters =
     statusFilter !== "all" ||
     campaignFilter !== "all" ||
-    (date?.from && date?.to);
+    (date?.from && date?.to) ||
+    (showMonth && monthFilter !== "all") ||
+    (showYear && yearFilter !== "all");
 
   const clearFilters = () => {
     setStatusFilter("all");
     setCampaignFilter("all");
     setDate(undefined);
+    setMonthFilter("all");
+    setYearFilter("all");
     router.push(pathname);
   };
 
@@ -94,7 +107,12 @@ export default function FilterComponent({
       </CardHeader>
       <CardContent>
         <div className="space-y-4 sm:space-y-6">
-          <div className="grid md:grid-cols-3 gap-4">
+          <div
+            className={cn(
+              "grid gap-4",
+              showMonth || showYear ? "md:grid-cols-4" : "md:grid-cols-3"
+            )}
+          >
             <div className="space-y-2">
               <Label>{t("filters.status.label")}</Label>
               <Select
@@ -146,6 +164,63 @@ export default function FilterComponent({
                 </SelectContent>
               </Select>
             </div>
+
+            {showMonth && (
+              <div className="space-y-2">
+                <Label>{t("filters.month.label")}</Label>
+                <Select
+                  value={monthFilter}
+                  onValueChange={(value) => {
+                    setMonthFilter(value);
+                    updateSearchParams("month", value);
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("filters.month.all")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">
+                      {t("filters.month.all")}
+                    </SelectItem>
+                    {Array.from({ length: 12 }, (_, i) => (
+                      <SelectItem key={i + 1} value={`${i + 1}`}>{
+                        i + 1
+                      }</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {showYear && (
+              <div className="space-y-2">
+                <Label>{t("filters.year.label")}</Label>
+                <Select
+                  value={yearFilter}
+                  onValueChange={(value) => {
+                    setYearFilter(value);
+                    updateSearchParams("year", value);
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("filters.year.all")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">
+                      {t("filters.year.all")}
+                    </SelectItem>
+                    {Array.from({ length: 5 }, (_, i) => {
+                      const year = new Date().getFullYear() - i;
+                      return (
+                        <SelectItem key={year} value={`${year}`}>
+                          {year}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label>{t("filters.dateRange")}</Label>

--- a/affiliate-panel/components/transactions/FilterComponent.tsx
+++ b/affiliate-panel/components/transactions/FilterComponent.tsx
@@ -58,7 +58,9 @@ export default function FilterComponent({
       ? `${searchParams.get("month")}-${searchParams.get("year")}`
       : "all"
   );
-  const [yearFilter, setYearFilter] = useState(searchParams.get("year") || "all");
+  const [yearFilter, setYearFilter] = useState(
+    searchParams.get("year") || "all"
+  );
 
   const fromParam = searchParams.get("from");
   const toParam = searchParams.get("to");
@@ -120,7 +122,10 @@ export default function FilterComponent({
               "grid gap-4",
               (() => {
                 const cols =
-                  2 + (showMonth ? 1 : 0) + (showYear ? 1 : 0) + (showDateRange ? 1 : 0);
+                  2 +
+                  (showMonth ? 1 : 0) +
+                  (showYear ? 1 : 0) +
+                  (showDateRange ? 1 : 0);
                 return `md:grid-cols-${Math.min(cols, 4)}`;
               })()
             )}
@@ -206,7 +211,9 @@ export default function FilterComponent({
                         key={`${m.month}-${m.year}`}
                         value={`${m.month}-${m.year}`}
                       >
-                        {moment(`${m.year}-${String(m.month).padStart(2, "0")}-01`).format("MMMM - YYYY")}
+                        {moment(
+                          `${m.year}-${String(m.month).padStart(2, "0")}-01`
+                        ).format("MMMM - YYYY")}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -228,9 +235,7 @@ export default function FilterComponent({
                     <SelectValue placeholder={t("filters.year.all")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">
-                      {t("filters.year.all")}
-                    </SelectItem>
+                    <SelectItem value="all">{t("filters.year.all")}</SelectItem>
                     {Array.from({ length: 5 }, (_, i) => {
                       const year = new Date().getFullYear() - i;
                       return (

--- a/affiliate-panel/i18n/locales/en/common.json
+++ b/affiliate-panel/i18n/locales/en/common.json
@@ -147,6 +147,18 @@
   "noData": "No recent transactions found.",
   "viewAll": "View all transactions"
 },
+"reports": {
+  "title": "Reports",
+  "daily": "Daily",
+  "monthly": "Monthly",
+  "table": {
+    "date": "Date",
+    "month": "Month",
+    "transactions": "No. of Transactions",
+    "earning": "Earning",
+    "empty": "No data found."
+  }
+},
 "payments": {
   "paypalUpdated": "PayPal ID updated successfully",
   "errorUpdatingPaypal": "An error occurred while updating your PayPal ID",
@@ -337,6 +349,14 @@
   "campaign": {
     "label": "Campaign",
     "all": "All campaigns"
+  },
+  "month": {
+    "label": "Month",
+    "all": "All months"
+  },
+  "year": {
+    "label": "Year",
+    "all": "All years"
   },
   "dateRange": "Date Range",
   "placeholder": "Pick a date",

--- a/affiliate-panel/models/conversions-model/index.ts
+++ b/affiliate-panel/models/conversions-model/index.ts
@@ -681,11 +681,15 @@ export const getAffiliateDailyReport = async (
     campaignId,
     month,
     year,
+    from,
+    to,
   }: {
     status?: "pending" | "approved" | "declined" | "paid" | "untracked";
     campaignId?: string;
     month?: string;
     year?: string;
+    from?: string;
+    to?: string;
   }
 ) => {
   try {
@@ -693,8 +697,12 @@ export const getAffiliateDailyReport = async (
     const monthNum = month ? parseInt(month) : now.getMonth() + 1;
     const yearNum = year ? parseInt(year) : now.getFullYear();
 
-    const startDate = new Date(yearNum, monthNum - 1, 1);
-    const endDate = new Date(yearNum, monthNum, 0, 23, 59, 59, 999);
+    const startDate = from
+      ? new Date(from)
+      : new Date(yearNum, monthNum - 1, 1);
+    const endDate = to
+      ? new Date(to)
+      : new Date(yearNum, monthNum, 0, 23, 59, 59, 999);
 
     let whereConditions: any[] = [
       eq(affiliateConversionsSummary.affiliateId, affiliateId),
@@ -731,7 +739,11 @@ export const getAffiliateDailyReport = async (
 
     return { data: result, status: "success", message: "ok" };
   } catch (error: any) {
-    return { data: [], status: "error", message: error.message || "An error occurred" };
+    return {
+      data: [],
+      status: "error",
+      message: error.message || "An error occurred",
+    };
   }
 };
 
@@ -789,13 +801,15 @@ export const getAffiliateMonthlyReport = async (
 
     return { data: result, status: "success", message: "ok" };
   } catch (error: any) {
-    return { data: [], status: "error", message: error.message || "An error occurred" };
+    return {
+      data: [],
+      status: "error",
+      message: error.message || "An error occurred",
+    };
   }
 };
 
-export const getAffiliateAvailableMonths = async (
-  affiliateId: number
-) => {
+export const getAffiliateAvailableMonths = async (affiliateId: number) => {
   try {
     const result = await db
       .select({
@@ -813,12 +827,20 @@ export const getAffiliateAvailableMonths = async (
         sql`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt}), EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`
       )
       .orderBy(
-        desc(sql`EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`),
-        desc(sql`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt})`)
+        desc(
+          sql`EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`
+        ),
+        desc(
+          sql`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt})`
+        )
       );
 
     return { data: result, status: "success", message: "ok" };
   } catch (error: any) {
-    return { data: [], status: "error", message: error.message || "An error occurred" };
+    return {
+      data: [],
+      status: "error",
+      message: error.message || "An error occurred",
+    };
   }
 };

--- a/affiliate-panel/models/conversions-model/index.ts
+++ b/affiliate-panel/models/conversions-model/index.ts
@@ -792,3 +792,33 @@ export const getAffiliateMonthlyReport = async (
     return { data: [], status: "error", message: error.message || "An error occurred" };
   }
 };
+
+export const getAffiliateAvailableMonths = async (
+  affiliateId: number
+) => {
+  try {
+    const result = await db
+      .select({
+        month: sql<number>`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt})`,
+        year: sql<number>`EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`,
+      })
+      .from(affiliateConversionsSummary)
+      .where(
+        and(
+          eq(affiliateConversionsSummary.affiliateId, affiliateId),
+          ne(affiliateConversionsSummary.conversionStatus, "untracked")
+        )
+      )
+      .groupBy(
+        sql`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt}), EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`
+      )
+      .orderBy(
+        desc(sql`EXTRACT(YEAR FROM ${affiliateConversionsSummary.conversionCreatedAt})`),
+        desc(sql`EXTRACT(MONTH FROM ${affiliateConversionsSummary.conversionCreatedAt})`)
+      );
+
+    return { data: result, status: "success", message: "ok" };
+  } catch (error: any) {
+    return { data: [], status: "error", message: error.message || "An error occurred" };
+  }
+};

--- a/affiliate-panel/models/conversions-model/index.ts
+++ b/affiliate-panel/models/conversions-model/index.ts
@@ -673,3 +673,122 @@ export const getAffiliateConversionsSummaryByTrackingCode = async (
     };
   }
 };
+
+export const getAffiliateDailyReport = async (
+  affiliateId: number,
+  {
+    status,
+    campaignId,
+    month,
+    year,
+  }: {
+    status?: "pending" | "approved" | "declined" | "paid" | "untracked";
+    campaignId?: string;
+    month?: string;
+    year?: string;
+  }
+) => {
+  try {
+    const now = new Date();
+    const monthNum = month ? parseInt(month) : now.getMonth() + 1;
+    const yearNum = year ? parseInt(year) : now.getFullYear();
+
+    const startDate = new Date(yearNum, monthNum - 1, 1);
+    const endDate = new Date(yearNum, monthNum, 0, 23, 59, 59, 999);
+
+    let whereConditions: any[] = [
+      eq(affiliateConversionsSummary.affiliateId, affiliateId),
+      gte(affiliateConversionsSummary.conversionCreatedAt, startDate),
+      lte(affiliateConversionsSummary.conversionCreatedAt, endDate),
+    ];
+
+    if (status) {
+      whereConditions.push(
+        eq(affiliateConversionsSummary.conversionStatus, status)
+      );
+    } else {
+      whereConditions.push(
+        ne(affiliateConversionsSummary.conversionStatus, "untracked")
+      );
+    }
+
+    if (campaignId) {
+      whereConditions.push(
+        eq(affiliateConversionsSummary.campaignId, parseInt(campaignId))
+      );
+    }
+
+    const result = await db
+      .select({
+        date: sql<string>`DATE(${affiliateConversionsSummary.conversionCreatedAt})`,
+        transactions: count(),
+        earning: sql<string>`COALESCE(SUM(${affiliateConversionsSummary.commission}),0)`,
+      })
+      .from(affiliateConversionsSummary)
+      .where(and(...whereConditions))
+      .groupBy(sql`DATE(${affiliateConversionsSummary.conversionCreatedAt})`)
+      .orderBy(sql`DATE(${affiliateConversionsSummary.conversionCreatedAt})`);
+
+    return { data: result, status: "success", message: "ok" };
+  } catch (error: any) {
+    return { data: [], status: "error", message: error.message || "An error occurred" };
+  }
+};
+
+export const getAffiliateMonthlyReport = async (
+  affiliateId: number,
+  {
+    status,
+    campaignId,
+    year,
+  }: {
+    status?: "pending" | "approved" | "declined" | "paid" | "untracked";
+    campaignId?: string;
+    year?: string;
+  }
+) => {
+  try {
+    const now = new Date();
+    const yearNum = year ? parseInt(year) : now.getFullYear();
+
+    const startDate = new Date(yearNum, 0, 1);
+    const endDate = new Date(yearNum, 11, 31, 23, 59, 59, 999);
+
+    let whereConditions: any[] = [
+      eq(affiliateConversionsSummary.affiliateId, affiliateId),
+      gte(affiliateConversionsSummary.conversionCreatedAt, startDate),
+      lte(affiliateConversionsSummary.conversionCreatedAt, endDate),
+    ];
+
+    if (status) {
+      whereConditions.push(
+        eq(affiliateConversionsSummary.conversionStatus, status)
+      );
+    } else {
+      whereConditions.push(
+        ne(affiliateConversionsSummary.conversionStatus, "untracked")
+      );
+    }
+
+    if (campaignId) {
+      whereConditions.push(
+        eq(affiliateConversionsSummary.campaignId, parseInt(campaignId))
+      );
+    }
+
+    const result = await db
+      .select({
+        month: sql<number>`MONTH(${affiliateConversionsSummary.conversionCreatedAt})`,
+        transactions: count(),
+        earning: sql<string>`COALESCE(SUM(${affiliateConversionsSummary.commission}),0)`,
+      })
+      .from(affiliateConversionsSummary)
+      .where(and(...whereConditions))
+      .groupBy(sql`MONTH(${affiliateConversionsSummary.conversionCreatedAt})`)
+      .orderBy(sql`MONTH(${affiliateConversionsSummary.conversionCreatedAt})`);
+
+    return { data: result, status: "success", message: "ok" };
+  } catch (error: any) {
+    return { data: [], status: "error", message: error.message || "An error occurred" };
+  }
+};

--- a/affiliate-panel/utils/config.ts
+++ b/affiliate-panel/utils/config.ts
@@ -1,6 +1,7 @@
 import {
   CreditCard,
   FileText,
+  BarChart2,
   LayoutDashboard,
   LinkIcon,
   Settings,
@@ -43,6 +44,11 @@ export const Config = {
           name: "All Transactions",
           href: "/transactions",
           icon: FileText,
+        },
+        {
+          name: "Reports",
+          href: AppRoutes.reports,
+          icon: BarChart2,
         },
         {
           name: "Settings",

--- a/affiliate-panel/utils/routes.ts
+++ b/affiliate-panel/utils/routes.ts
@@ -11,5 +11,6 @@ export const AppRoutes = {
   links: "/links",
   payouts: "/payouts",
   transactions: "/transactions",
+  reports: "/reports",
   settings: "/settings",
 };


### PR DESCRIPTION
## Summary
- add optional month and year filters
- implement daily and monthly report queries
- create reports table component
- add reports page with tabbed filters
- expose `/reports` route and sidebar item
- update English translations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883584f97e4832db62cb2dfe65f0307